### PR TITLE
feat(stockreport): make report universal — remove hardcoded company/w…

### DIFF
--- a/app/routes/warehouse_routes.py
+++ b/app/routes/warehouse_routes.py
@@ -295,16 +295,12 @@ def view_stockreport_entries(item_id):
     # Use the first entry as a base for shared metadata
     first_entry = entries[0]
 
-    # ✅ Compute customs-related fields
-    atb_frist = customs_ozl = free_till = None
+    # Compute date-derived fields from the first T1 entry (if present)
+    atb_frist = free_till = None
     if first_entry.customs_status == "T1" and first_entry.entrance_date:
         atb_frist = first_entry.entrance_date.strftime("%d.%m.%Y")
-        customs_ozl = "OZL Hamburg"
         free_till = (first_entry.entrance_date + timedelta(days=90)).strftime("%d.%m.%Y")
-
-        # ✅ Attach to the first entry for template access
         setattr(first_entry, 'atb_first', atb_frist)
-        setattr(first_entry, 'customs_ozl', customs_ozl)
         setattr(first_entry, 'free_till', free_till)
 
     # ✅ Ensure signature fields are passed from entry if present
@@ -437,11 +433,10 @@ def view_stockreport_by_order(order_number):
     # Inherit report header fields from StockReportEntry (first entry)
     first_entry = entries[0] if entries else None
 
-    # Calculate customs info
-    atb_frist = customs_ozl = free_till = None
+    # Calculate date-derived fields from the first T1 entry (if present)
+    atb_frist = free_till = None
     if first_entry and first_entry.customs_status == "T1" and first_entry.entrance_date:
         atb_frist = first_entry.entrance_date.strftime("%d.%m.%Y")
-        customs_ozl = "OZL Hamburg"
         free_till = (first_entry.entrance_date + timedelta(days=90)).strftime("%d.%m.%Y")
 
     return render_template(
@@ -449,7 +444,6 @@ def view_stockreport_by_order(order_number):
         entries=entries,
         item=item,
         atb_frist=atb_frist,
-        customs_ozl=customs_ozl,
         free_till=free_till,
         signature_date_client=getattr(first_entry, 'signature_date_client', None) if first_entry else None,
         signature_client=getattr(first_entry, 'signature_client', None) if first_entry else None,

--- a/app/templates/edit_stockreport.html
+++ b/app/templates/edit_stockreport.html
@@ -17,13 +17,9 @@
     <div class="grid grid-cols-2 gap-4 mb-6">
       <div>
         <label class="block text-sm font-medium">Warehouse</label>
-        <select name="warehouse_address"
+        <input type="text" name="warehouse_address" value="{{ entry.warehouse_address or '' }}"
+          placeholder="e.g. Main Warehouse, Site B"
           class="w-full mt-1 border px-3 py-2 rounded bg-gray-50 dark:bg-gray-700 text-sm" required>
-          <option value="">Select Warehouse</option>
-          {% for wh in ["Pharmalogis", "iCargo", "Quehenberger", "Systra", "Schwarze"] %}
-          <option value="{{ wh }}" {% if entry.warehouse_address==wh %}selected{% endif %}>{{ wh }}</option>
-          {% endfor %}
-        </select>
       </div>
       <div>
         <label class="block text-sm font-medium">Pos. No.</label>
@@ -32,13 +28,9 @@
       </div>
       <div>
         <label class="block text-sm font-medium">Client</label>
-        <select name="client" class="w-full mt-1 border px-3 py-2 rounded bg-gray-50 dark:bg-gray-700 text-sm" required>
-          <option value="">Select Client</option>
-          {% for client in ["Anariti", "Aurora", "Jinling", "Lanhai", "Lekhim Vilnius", "Lekhim Kiev", "Osta", "PCC",
-          "Pharmalogis"] %}
-          <option value="{{ client }}" {% if entry.client==client %}selected{% endif %}>{{ client }}</option>
-          {% endfor %}
-        </select>
+        <input type="text" name="client" value="{{ entry.client or '' }}"
+          placeholder="Client name"
+          class="w-full mt-1 border px-3 py-2 rounded bg-gray-50 dark:bg-gray-700 text-sm" required>
       </div>
       <div>
         <label class="block text-sm font-medium">Client Ref.</label>
@@ -97,10 +89,9 @@
             <td class="p-2 border"><input type="text" name="sender" value="{{ entry.sender }}"
                 class="w-full px-2 py-1 rounded"></td>
             <td class="p-2 border">
-              <select name="customs_status" class="w-full px-2 py-1 rounded" onchange="updateCustomsDates()">
-                <option value="EU" {% if entry.customs_status=='EU' %}selected{% endif %}>EU</option>
-                <option value="T1" {% if entry.customs_status=='T1' %}selected{% endif %}>T1</option>
-              </select>
+              <input type="text" name="customs_status" value="{{ entry.customs_status or '' }}"
+                placeholder="e.g. EU, T1"
+                class="w-full px-2 py-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700">
             </td>
             <td class="p-2 border"><input type="text" name="stockref" value="{{ entry.stockref }}"
                 class="w-full px-2 py-1 rounded"></td>
@@ -111,17 +102,17 @@
 
     <div class="grid grid-cols-3 gap-4 mt-6 text-sm">
       <div>
-        <label class="block font-medium">ATB First:</label>
+        <label class="block font-medium">First Entry Date:</label>
         <input type="text" name="atb_frist" value="{{ atb_frist or '' }}"
           class="w-full mt-1 border px-3 py-1 rounded bg-gray-50 dark:bg-gray-700 text-sm">
       </div>
       <div>
-        <label class="block font-medium">Customs OZL:</label>
+        <label class="block font-medium">Reference No.:</label>
         <input type="text" name="customs_ozl" value="{{ customs_ozl or '' }}"
           class="w-full mt-1 border px-3 py-1 rounded bg-gray-50 dark:bg-gray-700 text-sm">
       </div>
       <div>
-        <label class="block font-medium">Free till:</label>
+        <label class="block font-medium">Valid Until:</label>
         <input type="text" name="free_till" value="{{ free_till or '' }}"
           class="w-full mt-1 border px-3 py-1 rounded bg-gray-50 dark:bg-gray-700 text-sm">
       </div>

--- a/app/templates/stockreport_form.html
+++ b/app/templates/stockreport_form.html
@@ -29,13 +29,8 @@
       <div class="grid grid-cols-2 gap-x-8 gap-y-4">
         <div>
           <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">Warehouse</label>
-          <select name="warehouse_address"
+          <input type="text" name="warehouse_address" placeholder="e.g. Main Warehouse, Site B"
             class="w-full border border-gray-300 dark:border-gray-600 px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-700 text-sm focus:ring-1 focus:ring-blue-500 focus:outline-none" required>
-            <option value="">Select Warehouse</option>
-            {% for w in ['Pharmalogis', 'iCargo', 'Quehenberger', 'Systra', 'Schwarze'] %}
-            <option value="{{ w }}">{{ w }}</option>
-            {% endfor %}
-          </select>
         </div>
         <div>
           <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">Pos. No.</label>
@@ -44,13 +39,8 @@
         </div>
         <div>
           <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">Client</label>
-          <select name="client"
+          <input type="text" name="client" placeholder="Client name"
             class="w-full border border-gray-300 dark:border-gray-600 px-3 py-2 rounded-md bg-gray-50 dark:bg-gray-700 text-sm focus:ring-1 focus:ring-blue-500 focus:outline-none" required>
-            <option value="">Select Client</option>
-            {% for c in ['Anariti', 'Aurora', 'Jinling', 'Lanhai', 'Lekhim Vilnius', 'Lekhim Kiev', 'Osta', 'PCC', 'Pharmalogis'] %}
-            <option value="{{ c }}">{{ c }}</option>
-            {% endfor %}
-          </select>
         </div>
         <div>
           <label class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">Client Ref.</label>
@@ -179,19 +169,19 @@
 
     <!-- Customs info -->
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-5 mb-5">
-      <h2 class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">Customs Information</h2>
+      <h2 class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">Additional Information</h2>
       <div class="grid grid-cols-3 gap-6 text-sm">
         <div>
-          <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">ATB First</label>
+          <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">First Entry Date</label>
           <span id="atb-frist" class="block text-gray-800 dark:text-gray-200 font-medium">—</span>
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Customs OZL</label>
-          <input type="text" name="customs_ozl"
+          <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Reference No.</label>
+          <input type="text" name="customs_ozl" placeholder="e.g. bond number, permit ref."
             class="w-full border border-gray-300 dark:border-gray-600 px-3 py-1.5 rounded-md bg-gray-50 dark:bg-gray-700 text-sm focus:ring-1 focus:ring-blue-500 focus:outline-none">
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Free Till</label>
+          <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Valid Until</label>
           <span id="free-till" class="block text-gray-800 dark:text-gray-200 font-medium">—</span>
         </div>
       </div>

--- a/app/templates/view_stockreport.html
+++ b/app/templates/view_stockreport.html
@@ -65,13 +65,9 @@
         <span class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">Warehouse</span>
         <div class="view-mode text-gray-900 dark:text-gray-100 font-medium">{{ item.warehouse_address or '—' }}</div>
         <div class="edit-header hidden">
-          <select name="warehouse_address"
+          <input type="text" name="warehouse_address" value="{{ item.warehouse_address or '' }}"
+            placeholder="e.g. Main Warehouse, Site B"
             class="w-full mt-0.5 border border-gray-300 dark:border-gray-600 px-2 py-1.5 rounded-md text-sm bg-gray-50 dark:bg-gray-700 focus:ring-1 focus:ring-blue-500 focus:outline-none">
-            <option value="">Select Warehouse</option>
-            {% for opt in ['Pharmalogis', 'iCargo', 'Quehenberger', 'Systra', 'Schwarze'] %}
-            <option value="{{ opt }}" {% if item.warehouse_address == opt %}selected{% endif %}>{{ opt }}</option>
-            {% endfor %}
-          </select>
         </div>
       </div>
       <div>
@@ -86,13 +82,9 @@
         <span class="block text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">Client</span>
         <div class="view-mode text-gray-900 dark:text-gray-100 font-medium">{{ item.client or '—' }}</div>
         <div class="edit-header hidden">
-          <select name="client"
+          <input type="text" name="client" value="{{ item.client or '' }}"
+            placeholder="Client name"
             class="w-full mt-0.5 border border-gray-300 dark:border-gray-600 px-2 py-1.5 rounded-md text-sm bg-gray-50 dark:bg-gray-700 focus:ring-1 focus:ring-blue-500 focus:outline-none">
-            <option value="">Select Client</option>
-            {% for opt in ['Anariti', 'Aurora', 'Jinling', 'Lanhai', 'Lekhim Vilnius', 'Lekhim Kiev', 'Osta', 'PCC', 'Pharmalogis'] %}
-            <option value="{{ opt }}" {% if item.client == opt %}selected{% endif %}>{{ opt }}</option>
-            {% endfor %}
-          </select>
         </div>
       </div>
       <div>
@@ -137,11 +129,9 @@
               <div class="view-mode text-gray-800 dark:text-gray-200">{{ entry | lookup(field) or '—' }}</div>
               <div class="edit-header hidden">
                 {% if field == "customs_status" %}
-                <select name="{{ field }}"
+                <input type="text" name="{{ field }}" value="{{ entry | lookup(field) or '' }}"
+                  placeholder="e.g. EU, T1, In-Bond"
                   class="w-full px-1 py-0.5 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-xs focus:ring-1 focus:ring-blue-500 focus:outline-none">
-                  <option value="EU" {% if entry | lookup(field) == 'EU' %}selected{% endif %}>EU</option>
-                  <option value="T1" {% if entry | lookup(field) == 'T1' %}selected{% endif %}>T1</option>
-                </select>
                 {% elif field in ["colli", "pcs", "colli_per_pal", "pcs_total", "pal", "gross_kg", "net_kg"] %}
                 <input type="number" name="{{ field }}" value="{{ entry | lookup(field) }}"
                   class="w-full px-1 py-0.5 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-xs text-center focus:ring-1 focus:ring-blue-500 focus:outline-none">
@@ -164,9 +154,9 @@
 
   <!-- Customs info -->
   <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-5 mb-5">
-    <h2 class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">Customs Information</h2>
+    <h2 class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">Additional Information</h2>
     <div class="grid grid-cols-3 gap-6 text-sm">
-      {% for label, field in [("ATB First", "atb_first"), ("Customs OZL", "customs_ozl"), ("Free Till", "free_till")] %}
+      {% for label, field in [("First Entry Date", "atb_first"), ("Reference No.", "customs_ozl"), ("Valid Until", "free_till")] %}
       <div>
         <span class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">{{ label }}</span>
         <div class="view-mode text-gray-800 dark:text-gray-200 font-medium">{{ item | lookup(field) or '—' }}</div>


### PR DESCRIPTION
…arehouse names

Warehouse and Client fields were dropdown selects populated with specific company names. Replace both with free-text inputs across all three templates (stockreport_form, view_stockreport, edit_stockreport) so any organisation can use the report without code changes.

Additional generalisations:
- Customs status column in view/edit: select (EU/T1 only) → text input with placeholder so any regime code is accepted
- "Customs Information" section renamed to "Additional Information"
- "ATB First" (German customs jargon) → "First Entry Date"
- "Customs OZL" (Offener Zolllager Hamburg-specific) → "Reference No." with a neutral placeholder; also remove the "OZL Hamburg" hardcode from the route — the field now starts blank and is user-entered
- "Free till" → "Valid Until"

## What

<!-- One sentence: what does this PR change? -->

## Why

<!-- Why is this change needed? Link to the issue: Closes #N -->

Closes #

## How

<!-- Brief description of implementation approach. Call out non-obvious choices. -->

## How to Test

```bash
# 1. Setup
flask db upgrade
python run.py

# 2. Steps to verify
# e.g. Visit /dashboard → filter by status → confirm results are deterministic

# 3. API check (if applicable)
curl -c /tmp/jar -b /tmp/jar http://127.0.0.1:5000/api/v1/orders?page=1&per_page=5
```

## Checklist

- [ ] Acceptance criteria from the issue are met
- [ ] No regressions: existing routes and API endpoints still work
- [ ] Demo mode still functional (auto-login, read-only guard)
- [ ] New behavior covered by a smoke test or manual test documented above
- [ ] Docs updated if any API, architecture, or decision changed
- [ ] `requirements.txt` updated if new dependencies added
- [ ] No secrets or real credentials committed

## Demo Artifact

<!-- Attach a screenshot or Loom link showing the change working -->
